### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "URead API",
   "main": "index.js",
   "repository": "https://github.com/stephanogiuseppe/uread-backend.git",
-  "author": "Stéphano Giuseppe <stephano.grp@gmail.com>",
+  "author": "StC)phano Giuseppe <stephano.grp@gmail.com>",
   "license": "MIT",
   "scripts": {
     "dev": "nodemon --watch 'src/**/*.ts' --ignore 'src/**/*.spec.ts' --exec ts-node src/index.ts"


### PR DESCRIPTION

Hello stephanogiuseppe!

It seems like you have npm as one of your (dev-) dependency in uread-backend.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
